### PR TITLE
Markdown and viewable by single author

### DIFF
--- a/distributed_social_network/api/models.py
+++ b/distributed_social_network/api/models.py
@@ -47,7 +47,7 @@ class Post(models.Model):
     origin = models.CharField(default='', max_length=200)
     categories = models.CharField(max_length=200) # Should be stored as space separated list of strings
     unlisted = models.BooleanField(default=False)
-    viewableBy = models.CharField(default='', max_length=200)
+    viewableBy = models.CharField(default='', max_length=200, blank=True)
 
 class Comment(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=True)

--- a/distributed_social_network/api/models.py
+++ b/distributed_social_network/api/models.py
@@ -47,6 +47,7 @@ class Post(models.Model):
     origin = models.CharField(default='', max_length=200)
     categories = models.CharField(max_length=200) # Should be stored as space separated list of strings
     unlisted = models.BooleanField(default=False)
+    viewableBy = models.CharField(default='', max_length=200)
 
 class Comment(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=True)

--- a/distributed_social_network/api/views/posts.py
+++ b/distributed_social_network/api/views/posts.py
@@ -49,6 +49,8 @@ def create_post(request):
 def create_post_with_id(request, id):
     # Use the given id
     request.data["id"] = id
+    if not request.data['viewableBy']:
+        request.data['viewableBy'] = ''
     response = HttpResponse()
 
     # Check authorization

--- a/distributed_social_network/api/views/posts.py
+++ b/distributed_social_network/api/views/posts.py
@@ -58,7 +58,8 @@ def create_post_with_id(request, id):
         if not token:
             token = request.headers['Authorization']
             if not token:
-                return None
+                response.status_code = 401
+                return response
         creatorId = jwt.decode(token, key='secret', algorithms=['HS256'])["id"]
         if not (str(request.data['author']) == creatorId):
             response.status_code = 401
@@ -96,8 +97,14 @@ def delete_post(request, id):
 
     # Check authorization
     try:
-        cookie = request.COOKIES['jwt']
-        deleterId = jwt.decode(cookie, key='secret', algorithms=['HS256'])["id"]
+        token = request.COOKIES.get('jwt')
+        # Request was not authenticated without a token
+        if not token:
+            token = request.headers['Authorization']
+            if not token:
+                response.status_code = 401
+                return response
+        deleterId = jwt.decode(token, key='secret', algorithms=['HS256'])["id"]
         if not (str(post.author_id) == deleterId):
             response.status_code = 401
             return response
@@ -126,8 +133,14 @@ def update_post(request, id):
 
     # Check authorization
     try:
-        cookie = request.COOKIES['jwt']
-        updaterId = jwt.decode(cookie, key='secret', algorithms=['HS256'])["id"]
+        token = request.COOKIES.get('jwt')
+        # Request was not authenticated without a token
+        if not token:
+            token = request.headers['Authorization']
+            if not token:
+                response.status_code = 401
+                return response
+        updaterId = jwt.decode(token, key='secret', algorithms=['HS256'])["id"]
         if not (str(post.author_id) == updaterId):
             response.status_code = 401
             return response
@@ -163,10 +176,34 @@ def get_post(request, id):
     if post.visibility == "FRIENDS":
         # Check if the current user is a friend of the author
         try:
-            cookie = request.COOKIES['jwt']
-            viewerId = uuid.UUID(jwt.decode(cookie, key='secret', algorithms=['HS256'])["id"])
+            token = request.COOKIES.get('jwt')
+            # Request was not authenticated without a token
+            if not token:
+                token = request.headers['Authorization']
+                if not token:
+                    response.status_code = 401
+                    return response
+            viewerId = uuid.UUID(jwt.decode(token, key='secret', algorithms=['HS256'])["id"])
             followRequests = FollowRequest.objects.filter(Q(actor__exact=authorId) | Q(object__exact=authorId)).filter(accepted__exact=True).filter(Q(actor__exact=viewerId) | Q(object__exact=viewerId))
             if len(followRequests) <= 0:
+                response.status_code = 401
+                return response
+        except KeyError:
+            response.status_code = 401
+            return response
+
+    # Check if post is viewable by single author only
+    if post.viewableBy != '':
+        try:
+            token = request.COOKIES.get('jwt')
+            # Request was not authenticated without a token
+            if not token:
+                token = request.headers['Authorization']
+                if not token:
+                    response.status_code = 401
+                    return response
+            viewerId = uuid.UUID(jwt.decode(token, key='secret', algorithms=['HS256'])["id"])
+            if viewerId != uuid.UUID(post.viewableBy) and viewerId != post.author_id:
                 response.status_code = 401
                 return response
         except KeyError:
@@ -185,18 +222,33 @@ def get_post(request, id):
 # Get all posts
 def get_multiple_posts(request):
     # Get all public posts that are not unlisted
-    publicPosts = Post.objects.filter(visibility__exact="PUBLIC").filter(unlisted__exact=False)
+    publicPosts = Post.objects.filter(visibility__exact="PUBLIC").filter(unlisted__exact=False).filter(viewableBy__exact='')
 
     friendsPosts = []
+    privatePosts = []
 
     # Get the current user id
     try:
-        cookie = request.COOKIES['jwt']
-        viewerId = uuid.UUID(jwt.decode(cookie, key='secret', algorithms=['HS256'])["id"])
+        token = request.COOKIES.get('jwt')
+        # Request was not authenticated without a token
+        if not token:
+            token = request.headers['Authorization']
+            if not token:
+                permissionForAny = False
+            else:
+                viewerId = uuid.UUID(jwt.decode(token, key='secret', algorithms=['HS256'])["id"])
 
-        # Get all friends only posts that are not unlisted
-        friendsPosts = Post.objects.filter(visibility__exact="FRIENDS").filter(unlisted__exact=False)
-        permissionForAny = True
+                # Get all friends only posts that are not unlisted
+                friendsPosts = Post.objects.filter(visibility__exact="FRIENDS").filter(unlisted__exact=False)
+                privatePosts = Post.objects.filter(~Q(viewableBy__exact='')).filter(unlisted__exact=False)
+                permissionForAny = True
+        else:
+            viewerId = uuid.UUID(jwt.decode(token, key='secret', algorithms=['HS256'])["id"])
+
+            # Get all friends only posts that are not unlisted
+            friendsPosts = Post.objects.filter(visibility__exact="FRIENDS").filter(unlisted__exact=False)
+            privatePosts = Post.objects.filter(~Q(viewableBy__exact='')).filter(unlisted__exact=False)
+            permissionForAny = True
     except KeyError:
         permissionForAny = False
 
@@ -206,8 +258,15 @@ def get_multiple_posts(request):
         for post in friendsPosts:
             # Check if the current user is a friend of the author
             followRequests = FollowRequest.objects.filter(Q(actor__exact=post.author_id) | Q(object__exact=post.author_id)).filter(accepted__exact=True).filter(Q(actor__exact=viewerId) | Q(object__exact=viewerId))
-            if len(followRequests) <= 0:
+            if len(followRequests) > 0:
                 allowedFriendsPosts.append(post)
+        
+        # Loop over private posts
+        allowedPrivatePosts = []
+        for post in privatePosts:
+            # Check if the current user is the viewableBy user
+            if uuid.UUID(post.viewableBy) == viewerId or post.author_id == viewerId:
+                allowedPrivatePosts.append(post)
 
     # Initialize paginator
     paginator = PageNumberPagination()
@@ -215,7 +274,7 @@ def get_multiple_posts(request):
     paginator.page_size_query_param = 'size'
 
     # Get posts, paginated
-    posts = paginator.paginate_queryset(list(chain(publicPosts, friendsPosts)), request)
+    posts = paginator.paginate_queryset(list(chain(publicPosts, allowedFriendsPosts, allowedPrivatePosts)), request)
 
     # Create the JSON response dictionary
     serializer = PostSerializer(posts, many=True)
@@ -242,10 +301,34 @@ def get_post_image(request, id):
     if post.visibility == "FRIENDS":
         # Check if the current user is a friend of the author
         try:
-            cookie = request.COOKIES['jwt']
-            viewerId = uuid.UUID(jwt.decode(cookie, key='secret', algorithms=['HS256'])["id"])
+            token = request.COOKIES.get('jwt')
+            # Request was not authenticated without a token
+            if not token:
+                token = request.headers['Authorization']
+                if not token:
+                    response.status_code = 401
+                    return response
+            viewerId = uuid.UUID(jwt.decode(token, key='secret', algorithms=['HS256'])["id"])
             followRequests = FollowRequest.objects.filter(Q(actor__exact=authorId) | Q(object__exact=authorId)).filter(accepted__exact=True).filter(Q(actor__exact=viewerId) | Q(object__exact=viewerId))
             if len(followRequests) <= 0:
+                response.status_code = 401
+                return response
+        except KeyError:
+            response.status_code = 401
+            return response
+
+    # Check if post is viewable by single author only
+    if post.viewableBy != '':
+        try:
+            token = request.COOKIES.get('jwt')
+            # Request was not authenticated without a token
+            if not token:
+                token = request.headers['Authorization']
+                if not token:
+                    response.status_code = 401
+                    return response
+            viewerId = uuid.UUID(jwt.decode(token, key='secret', algorithms=['HS256'])["id"])
+            if viewerId != uuid.UUID(post.viewableBy) and viewerId != post.author_id:
                 response.status_code = 401
                 return response
         except KeyError:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "react-dom": "^17.0.2",
     "react-file-base64": "^1.0.3",
     "react-router-dom": "^5.3.0",
+    "react-markdown": "8.0.0",
     "react-scripts": "5.0.0",
     "web-vitals": "^2.1.4",
     "yarn": "^1.22.17"

--- a/frontend/src/components/Inbox/Post.js
+++ b/frontend/src/components/Inbox/Post.js
@@ -12,6 +12,7 @@ import { Alert,
         ImageListItem,
         TextField,
         } from "@mui/material";
+import ReactMarkdown from 'react-markdown'
 import ThumbUp from '@mui/icons-material/ThumbUp'
 import Send from '@mui/icons-material/Send'
 
@@ -111,7 +112,10 @@ export default function Post(props) {
           id="author"
           primary={"By: " + props.author.displayName}
         />
-        {(props.contentType == "text/markdown" || props.contentType == "text/plain") && <ListItemText
+        {props.contentType == "text/markdown" && <ReactMarkdown>
+          {props.content}
+          </ReactMarkdown>}
+        {(props.contentType == "text/plain") && <ListItemText
           primary={props.content}
         />}
         {(props.contentType == "application/base64" || props.contentType == "image/png;base64" || props.contentType == "image/jpeg;base64") && <ImageListItem

--- a/frontend/src/components/Posts/NewPost.js
+++ b/frontend/src/components/Posts/NewPost.js
@@ -34,6 +34,7 @@ class NewPost extends Component {
     unlisted: false,
     successful_post: false,
     author_id: "",
+    viewableBy: "",
     jwt: localStorage.getItem("access_token"),
   };
 
@@ -66,6 +67,7 @@ class NewPost extends Component {
         visibility: this.state.visibility,
         unlisted: this.state.unlisted,
         categories: this.state.categories,
+        viewableBy: this.state.viewableBy,
       });
       //console.log(response.data);
       this.setState({ successful_post: true });
@@ -229,6 +231,20 @@ class NewPost extends Component {
               <MenuItem value="PUBLIC">Public</MenuItem>
               <MenuItem value="FRIENDS">Friends</MenuItem>
             </TextField>
+            <br />
+            <TextField
+              className="text-input"
+              size="small"
+              type="text"
+              fullWidth={true}
+              label="Post only to"
+              value={this.state.viewableBy}
+              onChange={({ target }) =>
+                this.setState({
+                  viewableBy: target.value,
+                })
+              }
+            />
             <br />
             <p>Unlisted</p>
             <input 

--- a/frontend/src/components/Posts/NewPost.js
+++ b/frontend/src/components/Posts/NewPost.js
@@ -234,6 +234,7 @@ class NewPost extends Component {
             <br />
             <TextField
               className="text-input"
+              defaultValue=""
               size="small"
               type="text"
               fullWidth={true}


### PR DESCRIPTION
This implements conditional markdown rendering for posts in the frontend if the content type is markdown. Also this covers the ability to create posts that are private to a single other author. All get post endpoints are configured to include this behaviour. Lastly I fixed the post endpoint requiring authentication to also check for the "Authorization" header in addition to the cookie.